### PR TITLE
Add phone dialpad layout

### DIFF
--- a/clavier/__init__.py
+++ b/clavier/__init__.py
@@ -1,4 +1,4 @@
 from .keyboard import Keyboard
-from .layouts import load_dvorak, load_qwerty
+from .layouts import load_dvorak, load_qwerty, load_dialpad
 
-__all__ = ["Keyboard", "load_dvorak", "load_qwerty"]
+__all__ = ["Keyboard", "load_dvorak", "load_qwerty", "load_dialpad"]

--- a/clavier/layouts.py
+++ b/clavier/layouts.py
@@ -23,3 +23,15 @@ def load_dvorak(**kwargs):
         """,
         **kwargs
     )
+
+
+def load_dialpad(**kwargs):
+    return Keyboard.from_grid(
+        """
+        1 2 3
+        4 5 6
+        7 8 9
+        * 0 #
+        """,
+        **kwargs
+    )

--- a/clavier/test_keyboard.py
+++ b/clavier/test_keyboard.py
@@ -15,3 +15,11 @@ def test_levenshtein(w1, w2, expected):
 
     keyboard.char_distance = mock_distance
     assert keyboard.word_distance(w1, w2) == expected
+
+
+def test_phone_number_distance() -> None:
+    dialpad = clavier.load_dialpad()
+    assert dialpad.word_distance("123", "423") == 1.0
+    assert dialpad.word_distance("123", "523") == pytest.approx(1.414, 0.001)
+    assert dialpad.word_distance("123", "183") == 2.0
+    assert dialpad.word_distance("1234", "123") == 1.0


### PR DESCRIPTION
Hey! This is a neat idea and library. Thanks for this.

My recent use case was finding similar, possibly mistyped mobile numbers, so I wanted to propose adding a basic phone dial pad layout.

Deliberately left out of scope:
- cleaning up input (keeping only what the keyboard allows)
- removing common `()- `
- substituting leading `+` with `00`

<details>
<summary>As an alternative...</summary>
I considered adding a full-size QWERTY keyboard with NumPad, but then you need to remove or do something hacky with the top number row.